### PR TITLE
gh-pages via hop

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,8 @@ description: An easier way to access storage APIs in the browser.
 homepage: https://github.com/sethladd/lawndart
 dependencies:
   unittest: any
+  bot:
+    git: https://github.com/kevmoo/bot.dart
   browser: any
   web_ui: any
   meta: any

--- a/tool/hop_runner.dart
+++ b/tool/hop_runner.dart
@@ -1,0 +1,9 @@
+library hop_runner;
+
+import 'package:bot/hop.dart';
+import 'package:bot/hop_tasks.dart';
+
+void main() {
+  addTask('docs', createDartDocTask(['lib/lawndart.dart'], linkApi: true));
+  runHopCore();
+}


### PR DESCRIPTION
Sample: http://kevmoo.github.com/lawndart/

Requires `dart` and `git` in your PATH

Try it yourself.

``` text
dart tool/hop_runner.dart docs
```

From the root of lawndart
