### PR TITLE
Implementations can be individually disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The factory constructor will try IndexedDB, then WebSQL, and then finally
 local storage. Of course, you can perform your own logic to choose which
 option works for you.
 
+You can also disable a specific implementation:
+
+      WebSqlStore.supported = false;
+      var db = new Store("simple-run-through", 'test');
+
+
 # API
 
 `Future open()`

--- a/lib/src/indexeddb_store.dart
+++ b/lib/src/indexeddb_store.dart
@@ -21,6 +21,7 @@ part of lawndart;
 class IndexedDbStore<V> extends Store<V> {
   
   static Map<String, idb.Database> _databases = new Map<String, idb.Database>();
+  static bool _enabled = true;
 
   final String dbName;
   final String storeName;
@@ -28,7 +29,8 @@ class IndexedDbStore<V> extends Store<V> {
   IndexedDbStore(this.dbName, this.storeName) : super._();
 
   /// Returns true if IndexedDB is supported on this platform.
-  static bool get supported => idb.IdbFactory.supported;
+  static bool get supported => _enabled ? idb.IdbFactory.supported : false;
+  static set supported(bool value) => _enabled = value;
 
   Future open() {
     if (!supported) {

--- a/lib/src/local_storage_store.dart
+++ b/lib/src/local_storage_store.dart
@@ -20,6 +20,12 @@ part of lawndart;
  * unless all other storage mechanisms are unavailable.
  */
 class LocalStorageStore<V> extends _MapStore<V> {
+  
+  static bool _enabled = true;
+  
+  static bool get supported => _enabled;
+  static set supported(bool value) => _enabled = value;
+
   @override
   Map _generateMap() {
     return window.localStorage;

--- a/lib/src/memory_store.dart
+++ b/lib/src/memory_store.dart
@@ -15,6 +15,12 @@
 part of lawndart;
 
 class MemoryStore<V> extends _MapStore<V> {
+  
+  static bool _enabled = true;
+  
+  static bool get supported => _enabled;
+  static set supported(bool value) => _enabled = value;
+
   @override
   Map<String, V> _generateMap() {
     return new Map<String, V>();

--- a/lib/src/websql_store.dart
+++ b/lib/src/websql_store.dart
@@ -22,6 +22,7 @@ class WebSqlStore<V> extends Store<V> {
 
   static final String VERSION = "1";
   static const int INITIAL_SIZE = 5 * 1024 * 1024;
+  static bool _enabled = true;
 
   String dbName;
   String storeName;
@@ -31,7 +32,8 @@ class WebSqlStore<V> extends Store<V> {
   WebSqlStore(this.dbName, this.storeName, {this.estimatedSize: INITIAL_SIZE}) : super._();
 
   /// Returns true if WebSQL is supported on this platform.
-  static bool get supported => SqlDatabase.supported;
+  static bool get supported => _enabled ? SqlDatabase.supported : false;
+  static set supported(bool value) => _enabled = value;
 
   @override
   Future<bool> open() {


### PR DESCRIPTION
You can also disable a specific implementation:

```
  WebSqlStore.supported = false;
  var db = new Store("simple-run-through", 'test');
```

Fixes #19.
